### PR TITLE
삭제 함수 버그 수정

### DIFF
--- a/RegistrationProgram/delete_member.c
+++ b/RegistrationProgram/delete_member.c
@@ -48,6 +48,7 @@ void delete_member()
 	// 회원이 검색되지 않았으면 존재하지 않다고 출력
 	if (flag == 0) {
 		printf("회원이 존재하지 않습니다.\n");
+		return -1;
 	}
 	printf("삭제가 완료되었습니다\n");
 }


### PR DESCRIPTION
delete_member() 함수에서 회원이 검색되지 않았을 때 출력메세지를 출력하고 
함수를 종료해야하는데 종료하지 않아서 그 부분 수정